### PR TITLE
Removing unnecessary packed modifier on EpollEvent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ impl Hash for EpollData {
 
 /// An event, such as that a file is available for reading.
 /// Transmute compatible with `libc::epoll_event`
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EpollEvent {
     pub events: Opts,


### PR DESCRIPTION
### What's Wrong
When cross compiling for ARM this modifier causes the struct to be packed wrong, leading to `::fd` always returning 0

```
+++expected
---actual

struct PollEvent {
    int32 opts;
+   char[4] _padding;
-
    union EpollData data;
}
```

### Reproduced on
Debian GNU/Linux 11 (bullseye)
rustc 1.71.0 (8ede3aae2 2023-07-12)